### PR TITLE
Initiate project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,144 @@
+Inter App Request Identifiers
+=============================
+
+Defines an interface to identify a process running between multiple applications.
+
+When you work with multiple application calling each other, it is hard to follow which application calls which other application.  
+Furthermore, when you have to see the logs of an application, you can not see where the request come from.
+
+This library provides a solution:
+* when an application calls another one, it adds some identifiers in the request header to keep track of who is the caller
+* when an application receives a call from another one, it checks if the headers are set and will use them for further request
+* it adds an extra section in your monolog logs containing:
+  * an identification of the current application process
+  * an identification of the caller who initiate the call to this application
+  * an identification of the root caller who initiate the global call.
+
+Installation
+------------
+
+```bash
+composer require juliendufresne/inter-app-request-identifier
+```
+
+Example
+-------
+
+```php
+use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\RamseyUuidGenerator;
+use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromConsoleFactory;
+use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromRequestFactory;
+
+$generator = new RamseyUuidGenerator();
+
+$factory = RequestIdFromConsoleFactory($generator);
+$requestIdentifier = $factory->create();
+
+// or, if the current process is coming from the web
+
+$factory = new RequestIdFromRequestFactory($generator, 'X-Root-Request-Id', 'X-Parent-Request-Id');
+// will search for 'X-Root-Request-Id' and 'X-Parent-Request-Id' in $_SERVER array.
+// Be careful that $_SERVEr prefix headers with HTTP_
+// You might want to set headers to HTTP_X-Root-Request-Id
+$requestIdentifier = $factory->create($_SERVER);
+```
+
+Generator
+---------
+
+Generator is used to generate unique request id for the current running application.  
+
+This library provides one default generator: the [RamseyUuidGenerator](/src/Factory/Generator/RamseyUuidGenerator.php).  
+If you want to use it, you must install the [`ramsey/uuid`](https://packagist.org/packages/ramsey/uuid) package.
+
+You can define your own generator by implementing the [UniqueIdGeneratorInterface](/src/Factory/Generator/UniqueIdGeneratorInterface.php)
+
+Guzzle
+------
+
+If you are using guzzle (package guzzlehttp/guzzle) to perform http requests, you can either add the RequestIdMiddleware to your handler stack:
+ 
+```php
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+
+$requestIdMiddleware = new RequestIdMiddleware(/* $requestIdentifier */);
+
+$stack = HandlerStack::create();
+$stack->push(Middleware::mapRequest($requestIdMiddleware));
+
+$client = new Client(['handler' => $stack]);
+```
+ 
+ 
+or use our factory to create a guzzle client:
+
+```php
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\ClientFactory;
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+
+$requestIdMiddleware = new RequestIdMiddleware(/* $requestIdentifier */);
+
+$factory = new ClientFactory();
+$client = $factory->create();
+```
+
+### Changing the headers sent
+
+By default, sent headers are:
+* `X-Root-Request-Id` for the root application identifier
+* `X-Parent-Request-Id` for the current application identifier (that will become the parent application of the http request)
+
+You can change this in the middleware:
+
+```php
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+
+$requestIdMiddleware = new RequestIdMiddleware(
+    /* $requestIdentifier */,
+    'X-Root-Request-Id',
+    'X-Parent-Request-Id'
+);
+```
+
+Keep in mind that if you change this, you might want to change this in every applications
+
+Monolog
+-------
+
+If you are using monolog to manage your application logs, you can use the [RequestIdentifierProcessor](/src/Monolog/RequestIdentifierProcessor.php):
+
+```php
+use JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor;
+use Monolog\Logger;
+
+$processor = new RequestIdentifierProcessor(/* $requestIdentifier */);
+
+$logger = new Logger('channel-name');
+$logger->pushProcessor([$processor]);
+
+$logger->addInfo('message');
+```
+
+### Changing the extra keys
+
+By default, the processor will add a `request_id` array entry in the `extra` section with the following keys:
+* `current` for the current application identifier
+* `root` for the root application identifier
+* `parent` for the parent application identifier
+
+You can change this in the processor instantiation:
+
+```php
+use JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor;
+
+$processor = new RequestIdentifierProcessor(
+    /* $requestIdentifier */,
+    'request_id',
+    'current',
+    'root',
+    'parent'
+);
+```

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,15 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
+        "guzzlehttp/guzzle": "^6.3",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
         "jakub-onderka/php-parallel-lint": "^1.0",
+        "monolog/monolog": "^1.23",
         "phpmetrics/phpmetrics": "^2.3",
         "phpstan/phpstan": "^0.9.2",
         "phpstan/phpstan-phpunit": "^0.9.4",
         "phpunit/phpunit": "^7.0",
+        "ramsey/uuid": "^3.7",
         "sensiolabs/security-checker": "^4.1"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,5 @@
 includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon
+parameters:
+    autoload_files:
+        - %rootDir%/../../../tests/Factory/Generator/RamseyUuidGeneratorTest.php

--- a/src/Factory/AbstractRequestIdentifierFactory.php
+++ b/src/Factory/AbstractRequestIdentifierFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Factory;
+
+use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
+
+abstract class AbstractRequestIdentifierFactory
+{
+    /** @var UniqueIdGeneratorInterface */
+    protected $uniqueIdentifierGenerator;
+
+    public function __construct(UniqueIdGeneratorInterface $uniqueIdentifierGenerator)
+    {
+        $this->uniqueIdentifierGenerator = $uniqueIdentifierGenerator;
+    }
+}

--- a/src/Factory/Generator/RamseyUuidGenerator.php
+++ b/src/Factory/Generator/RamseyUuidGenerator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator;
+
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Generates unique identifier based on the ramsey/uuid lib.
+ */
+final class RamseyUuidGenerator implements UniqueIdGeneratorInterface
+{
+    /**
+     * Generates an unique identifier each time the function is called.
+     *
+     * @return string
+     */
+    public function generateUniqueIdentifier(): string
+    {
+        if (!class_exists(Uuid::class)) {
+            throw new \LogicException(sprintf('%s requires ramsey/uuid library', __CLASS__));
+        }
+
+        return Uuid::uuid4()->toString();
+    }
+}

--- a/src/Factory/Generator/UniqueIdGeneratorInterface.php
+++ b/src/Factory/Generator/UniqueIdGeneratorInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator;
+
+/**
+ * Interface that your generator must implement to provide a way to generate unique identifier.
+ * It is used to generate an unique identifier for the current application execution.
+ *
+ * The generated string must be unique across every application.
+ */
+interface UniqueIdGeneratorInterface
+{
+    /**
+     * Generates an unique identifier each time the function is called.
+     *
+     * @return string
+     */
+    public function generateUniqueIdentifier(): string;
+}

--- a/src/Factory/RequestIdFromConsoleFactory.php
+++ b/src/Factory/RequestIdFromConsoleFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Factory;
+
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifier;
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+
+final class RequestIdFromConsoleFactory extends AbstractRequestIdentifierFactory
+{
+    public function create(?string $parentRequestId = null, ?string $rootRequestId = null): RequestIdentifierInterface
+    {
+        $current = $this->uniqueIdentifierGenerator->generateUniqueIdentifier();
+
+        return new RequestIdentifier($current, $parentRequestId, $rootRequestId);
+    }
+}

--- a/src/Factory/RequestIdFromRequestFactory.php
+++ b/src/Factory/RequestIdFromRequestFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Factory;
+
+use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifier;
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+
+final class RequestIdFromRequestFactory extends AbstractRequestIdentifierFactory
+{
+    /** @var string */
+    private $parentRequestIdHeaderName;
+    /** @var string */
+    private $rootRequestIdHeaderName;
+
+    public function __construct(
+        UniqueIdGeneratorInterface $uniqueIdentifierGenerator,
+        string $rootRequestIdHeaderName = 'X-Root-Request-Id',
+        string $parentRequestIdHeaderName = 'X-Parent-Request-Id'
+    ) {
+        parent::__construct($uniqueIdentifierGenerator);
+        $this->parentRequestIdHeaderName = $parentRequestIdHeaderName;
+        $this->rootRequestIdHeaderName = $rootRequestIdHeaderName;
+    }
+
+    /**
+     * @param string[] $requestHeaders list of all your request headers
+     *
+     * @return RequestIdentifierInterface
+     */
+    public function create(array $requestHeaders): RequestIdentifierInterface
+    {
+        $current = $this->uniqueIdentifierGenerator->generateUniqueIdentifier();
+
+        return new RequestIdentifier(
+            $current,
+            $requestHeaders[$this->parentRequestIdHeaderName] ?? null,
+            $requestHeaders[$this->rootRequestIdHeaderName] ?? null
+        );
+    }
+}

--- a/src/Guzzle/ClientFactory.php
+++ b/src/Guzzle/ClientFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Guzzle;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+
+final class ClientFactory
+{
+    /** @var RequestIdMiddleware */
+    private $middleware;
+
+    public function __construct(RequestIdMiddleware $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    public function create(array $config = []): Client
+    {
+        $config['handler'] = $this->injectMiddleware($config['handler'] ?? HandlerStack::create());
+
+        return new Client($config);
+    }
+
+    private function injectMiddleware(HandlerStack $handler): HandlerStack
+    {
+        $handler->push(Middleware::mapRequest($this->middleware));
+
+        return $handler;
+    }
+}

--- a/src/Guzzle/RequestIdMiddleware.php
+++ b/src/Guzzle/RequestIdMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Guzzle;
+
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use Psr\Http\Message\RequestInterface;
+
+/*final */class RequestIdMiddleware
+{
+    const DEFAULT_REQUEST_HEADER_NAME_ROOT = 'X-Root-Request-Id';
+    const DEFAULT_REQUEST_HEADER_NAME_PARENT = 'X-Parent-Request-Id';
+
+    /** @var RequestIdentifierInterface */
+    private $requestIdentifier;
+    /** @var string */
+    private $parentAppRequestHeaderName;
+    /** @var string */
+    private $rootAppRequestHeaderName;
+
+    public function __construct(
+        RequestIdentifierInterface $requestIdentifier,
+        string $rootAppRequestHeaderName = self::DEFAULT_REQUEST_HEADER_NAME_ROOT,
+        string $parentAppRequestHeaderName = self::DEFAULT_REQUEST_HEADER_NAME_PARENT
+    ) {
+        $this->requestIdentifier = $requestIdentifier;
+        $this->rootAppRequestHeaderName = $rootAppRequestHeaderName;
+        $this->parentAppRequestHeaderName = $parentAppRequestHeaderName;
+    }
+
+    public function __invoke(RequestInterface $request)
+    {
+        $headers = array_filter(
+            [
+                $this->rootAppRequestHeaderName => $this->requestIdentifier->getRootAppRequestId(),
+                $this->parentAppRequestHeaderName => $this->requestIdentifier->getCurrentAppRequestId(),
+            ]
+        );
+
+        foreach ($headers as $headerName => $headerValue) {
+            $request = $request->withHeader($headerName, $headerValue);
+        }
+
+        return $request;
+    }
+}

--- a/src/Monolog/RequestIdentifierProcessor.php
+++ b/src/Monolog/RequestIdentifierProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Monolog;
+
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+
+final class RequestIdentifierProcessor
+{
+    /** @var string */
+    private $extraEntryName;
+    /** @var RequestIdentifierInterface */
+    private $requestIdentifier;
+    /** @var string */
+    private $rootAppEntryName;
+    /** @var string */
+    private $parentAppEntryName;
+    /** @var string */
+    private $currentAppEntryName;
+
+    /**
+     * @param RequestIdentifierInterface $requestIdentifier
+     * @param string                     $extraEntryName
+     * @param string                     $currentAppEntryName
+     * @param string                     $rootAppEntryName
+     * @param string                     $parentAppEntryName
+     */
+    public function __construct(
+        RequestIdentifierInterface $requestIdentifier,
+        string $extraEntryName = 'request_id',
+        string $currentAppEntryName = 'current',
+        string $rootAppEntryName = 'root',
+        string $parentAppEntryName = 'parent'
+    ) {
+        $this->currentAppEntryName = $currentAppEntryName;
+        $this->rootAppEntryName = $rootAppEntryName;
+        $this->parentAppEntryName = $parentAppEntryName;
+        $this->extraEntryName = $extraEntryName;
+        $this->requestIdentifier = $requestIdentifier;
+    }
+
+    public function __invoke(array $record)
+    {
+        $extra = array_filter([
+            $this->currentAppEntryName => $this->requestIdentifier->getCurrentAppRequestId(),
+            $this->rootAppEntryName => $this->requestIdentifier->getRootAppRequestId(),
+            $this->parentAppEntryName => $this->requestIdentifier->getParentAppRequestId(),
+        ]);
+
+        if ([] !== $extra) {
+            $record['extra'][$this->extraEntryName] = $extra;
+        }
+
+        return $record;
+    }
+}

--- a/src/RequestIdentifier.php
+++ b/src/RequestIdentifier.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier;
+
+/**
+ * Determines the context of the application's current execution.
+ */
+final class RequestIdentifier implements RequestIdentifierInterface
+{
+    /** @var string */
+    private $root;
+
+    /** @var string|null */
+    private $parent;
+
+    /** @var string */
+    private $current;
+
+    public function __construct(string $current, ?string $parent = null, ?string $root = null)
+    {
+        $this->current = $current;
+        $this->root = $root ?? $parent ?? $current;
+        $this->parent = $parent ?? $root;
+    }
+
+    public function getRootAppRequestId(): string
+    {
+        return $this->root;
+    }
+
+    public function getParentAppRequestId(): ?string
+    {
+        return $this->parent;
+    }
+
+    public function getCurrentAppRequestId(): string
+    {
+        return $this->current;
+    }
+}

--- a/src/RequestIdentifierFacade.php
+++ b/src/RequestIdentifierFacade.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier;
+
+/**
+ * Ensure process identifier is set only once at runtime.
+ */
+final class RequestIdentifierFacade implements RequestIdentifierInterface
+{
+    /** @var RequestIdentifierInterface|null */
+    private $requestIdentifier;
+
+    public function __construct(?RequestIdentifierInterface $requestIdentifier = null)
+    {
+        $this->requestIdentifier = $requestIdentifier;
+    }
+
+    public function initRequestIdentifier(RequestIdentifierInterface $requestIdentifier): void
+    {
+        if (null !== $this->requestIdentifier) {
+            throw new \LogicException('Can not reset process identifier');
+        }
+        $this->requestIdentifier = $requestIdentifier;
+    }
+
+    /**
+     * Uniquely identifies the root application execution id.
+     *
+     * @return string
+     */
+    public function getRootAppRequestId(): string
+    {
+        return null === $this->requestIdentifier ? '' : $this->requestIdentifier->getRootAppRequestId();
+    }
+
+    /**
+     * Uniquely identifies the execution id of this application's caller.
+     *
+     * @return string|null
+     */
+    public function getParentAppRequestId(): ?string
+    {
+        return null === $this->requestIdentifier ? null : $this->requestIdentifier->getParentAppRequestId();
+    }
+
+    /**
+     * Uniquely identifies the execution id of this application.
+     *
+     * @return string
+     */
+    public function getCurrentAppRequestId(): string
+    {
+        return null === $this->requestIdentifier ? '' : $this->requestIdentifier->getCurrentAppRequestId();
+    }
+}

--- a/src/RequestIdentifierInterface.php
+++ b/src/RequestIdentifierInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier;
+
+interface RequestIdentifierInterface
+{
+    /**
+     * Uniquely identifies the root application execution id.
+     *
+     * @return string
+     */
+    public function getRootAppRequestId(): string;
+
+    /**
+     * Uniquely identifies the execution id of this application's caller.
+     *
+     * @return string|null
+     */
+    public function getParentAppRequestId(): ?string;
+
+    /**
+     * Uniquely identifies the execution id of this application.
+     *
+     * @return string
+     */
+    public function getCurrentAppRequestId(): string;
+}

--- a/tests/Factory/Generator/RamseyUuidGeneratorTest.php
+++ b/tests/Factory/Generator/RamseyUuidGeneratorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    $mockClassExistsFunction = false;
+}
+
+namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator {
+    // override the global class_exists function used in the RamseyUuidGenerator class to test both scenario
+    function class_exists($className)
+    {
+        global $mockClassExistsFunction;
+
+        if (isset($mockClassExistsFunction) && $mockClassExistsFunction) {
+            return false;
+        }
+
+        return call_user_func('\class_exists', $className);
+    }
+}
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests\Factory\Generator {
+    use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\RamseyUuidGenerator;
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @covers \JulienDufresne\InterAppRequestIdentifier\Factory\Generator\RamseyUuidGenerator
+     */
+    final class RamseyUuidGeneratorTest extends TestCase
+    {
+        public function setUp()
+        {
+            global $mockClassExistsFunction;
+
+            $mockClassExistsFunction = false;
+        }
+
+        public function testGenerateUniqueIdentifier(): void
+        {
+            $object = new RamseyUuidGenerator();
+
+            $result1 = $object->generateUniqueIdentifier();
+            $result2 = $object->generateUniqueIdentifier();
+
+            $this->assertNotSame($result1, $result2);
+        }
+
+        public function testGenerateUniqueIdentifierWhenPackageDoesNotExists(): void
+        {
+            global $mockClassExistsFunction;
+            $mockClassExistsFunction = true;
+
+            $object = new RamseyUuidGenerator();
+            $this->expectException(\LogicException::class);
+
+            $object->generateUniqueIdentifier();
+        }
+    }
+}

--- a/tests/Factory/RequestIdFromConsoleFactoryTest.php
+++ b/tests/Factory/RequestIdFromConsoleFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests\Factory;
+
+use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromConsoleFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromConsoleFactory
+ */
+final class RequestIdFromConsoleFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $generator = $this->createMock(UniqueIdGeneratorInterface::class);
+        $generator->expects(self::once())
+            ->method('generateUniqueIdentifier')
+            ->willReturn('foo');
+
+        $object = new RequestIdFromConsoleFactory($generator);
+        $result = $object->create('bar', 'baz');
+
+        $this->assertEquals('foo', $result->getCurrentAppRequestId());
+        $this->assertEquals('bar', $result->getParentAppRequestId());
+        $this->assertEquals('baz', $result->getRootAppRequestId());
+    }
+}

--- a/tests/Factory/RequestIdFromRequestFactoryTest.php
+++ b/tests/Factory/RequestIdFromRequestFactoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests\Factory;
+
+use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromRequestFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromRequestFactory
+ */
+final class RequestIdFromRequestFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider provideHeaders
+     *
+     * @param array       $headers
+     * @param string      $expectedCurrentRequestId
+     * @param string|null $expectedParentRequestId
+     * @param string|null $expectedRootRequestId
+     *
+     * @throws \ReflectionException
+     */
+    public function testCreate(
+        array $headers,
+        string $expectedCurrentRequestId,
+        ?string $expectedParentRequestId,
+        ?string $expectedRootRequestId
+    ) {
+        $generator = $this->createMock(UniqueIdGeneratorInterface::class);
+        $generator->expects(self::once())
+                  ->method('generateUniqueIdentifier')
+                  ->willReturn($expectedCurrentRequestId);
+
+        $object = new RequestIdFromRequestFactory($generator, 'X-Root-Request-Id', 'X-Parent-Request-Id');
+        $result = $object->create($headers);
+
+        $this->assertEquals($expectedCurrentRequestId, $result->getCurrentAppRequestId());
+        $this->assertEquals($expectedParentRequestId, $result->getParentAppRequestId());
+        $this->assertEquals($expectedRootRequestId, $result->getRootAppRequestId());
+    }
+
+    public function provideHeaders()
+    {
+        return [
+            'nothing in headers' => [
+                'headers' => [
+                    'Accept' => '*/*',
+                    'Accept-Language' => 'en-us',
+                    'Accept-Encoding' => 'gzip, deflate',
+                    'User-Agent' => 'Mozilla/4.0',
+                    'Host' => 'www.example.com',
+                    'Connection' => 'Keep-Alive',
+                ],
+                'foo',
+                null,
+                'foo', // this should be the same as the second argument
+            ],
+            'only parent header is found' => [
+                'headers' => [
+                    'X-Parent-Request-Id' => 'baz',
+                    'Accept' => '*/*',
+                    'Accept-Language' => 'en-us',
+                    'Accept-Encoding' => 'gzip, deflate',
+                    'User-Agent' => 'Mozilla/4.0',
+                    'Host' => 'www.example.com',
+                    'Connection' => 'Keep-Alive',
+                ],
+                'foo',
+                'baz',
+                'baz',
+            ],
+            'only root header is found' => [
+                'headers' => [
+                    'X-Root-Request-Id' => 'baz',
+                    'Accept' => '*/*',
+                    'Accept-Language' => 'en-us',
+                    'Accept-Encoding' => 'gzip, deflate',
+                    'User-Agent' => 'Mozilla/4.0',
+                    'Host' => 'www.example.com',
+                    'Connection' => 'Keep-Alive',
+                ],
+                'foo',
+                'baz',
+                'baz',
+            ],
+            'both header are found' => [
+                'headers' => [
+                    'X-Parent-Request-Id' => 'bar',
+                    'X-Root-Request-Id' => 'baz',
+                    'Accept' => '*/*',
+                    'Accept-Language' => 'en-us',
+                    'Accept-Encoding' => 'gzip, deflate',
+                    'User-Agent' => 'Mozilla/4.0',
+                    'Host' => 'www.example.com',
+                    'Connection' => 'Keep-Alive',
+                ],
+                'foo',
+                'bar',
+                'baz',
+            ],
+        ];
+    }
+}

--- a/tests/Guzzle/ClientFactoryTest.php
+++ b/tests/Guzzle/ClientFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests\Guzzle;
+
+use GuzzleHttp\HandlerStack;
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\ClientFactory;
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JulienDufresne\InterAppRequestIdentifier\Guzzle\ClientFactory
+ */
+final class ClientFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $middlewareMocked = $this->createMock(RequestIdMiddleware::class);
+
+        $object = new ClientFactory($middlewareMocked);
+
+        $result = $object->create();
+
+        $this->assertArrayHasKey('handler', $result->getConfig());
+    }
+
+    public function testCreateWithoutHandler()
+    {
+        $middlewareMocked = $this->createMock(RequestIdMiddleware::class);
+
+        $object = new ClientFactory($middlewareMocked);
+
+        $result = $object->create(['handler' => HandlerStack::create()]);
+
+        $this->assertArrayHasKey('handler', $result->getConfig());
+    }
+}

--- a/tests/Guzzle/RequestIdMiddlewareTest.php
+++ b/tests/Guzzle/RequestIdMiddlewareTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests\Guzzle;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+final class RequestIdMiddlewareTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     *
+     * @param string|null $rootHeaderValue
+     * @param string|null $parentHeaderValue
+     *
+     * @throws \ReflectionException
+     */
+    public function testAddRequestIdentifier(?string $rootHeaderValue, ?string $parentHeaderValue)
+    {
+        $rootHeaderName = 'X-root';
+        $parentHeaderName = 'X-parent';
+
+        $h = new MockHandler(
+            [
+                function (RequestInterface $request) use ($rootHeaderValue, $rootHeaderName, $parentHeaderName, $parentHeaderValue) {
+                    if ($rootHeaderValue) {
+                        $this->assertEquals($rootHeaderValue, $request->getHeaderLine($rootHeaderName));
+                    } else {
+                        $this->assertFalse($request->hasHeader($rootHeaderName));
+                    }
+                    if ($parentHeaderValue) {
+                        $this->assertEquals($parentHeaderValue, $request->getHeaderLine($parentHeaderName));
+                    } else {
+                        $this->assertFalse($request->hasHeader($parentHeaderName));
+                    }
+
+                    return new Response(200);
+                },
+            ]
+        );
+        $requestIdentifierMock = $this->createMock(RequestIdentifierInterface::class);
+        $requestIdentifierMock->expects(self::once())
+                                    ->method('getRootAppRequestId')
+                                    ->willReturn($rootHeaderValue);
+        $requestIdentifierMock->expects(self::once())
+                                    ->method('getCurrentAppRequestId')
+                                    ->willReturn($parentHeaderValue);
+
+        $m = new RequestIdMiddleware($requestIdentifierMock, $rootHeaderName, $parentHeaderName);
+        $stack = new HandlerStack($h);
+        $stack->push(Middleware::mapRequest($m));
+        $comp = $stack->resolve();
+        /** @var PromiseInterface $p */
+        $p = $comp(new Request('GET', 'http://www.google.com'), []);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
+        $response = $p->wait();
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function provider(): array
+    {
+        return [
+            'no header' => [
+                '', '',
+            ],
+            'parent header' => [
+                '', 'foo',
+            ],
+            'root header' => [
+                'foo',
+                '',
+            ],
+            'every headers' => [
+                'foo',
+                'bar',
+            ],
+        ];
+    }
+}

--- a/tests/Monolog/RequestIdentifierProcessorTest.php
+++ b/tests/Monolog/RequestIdentifierProcessorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests\Monolog;
+
+use JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor;
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor
+ */
+final class RequestIdentifierProcessorTest extends TestCase
+{
+    public function testProcessor()
+    {
+        $values = [
+            'current' => 'A',
+            'root' => 'B',
+            'parent' => 'C',
+        ];
+
+        $requestIdentifierMock = $this->createMock(RequestIdentifierInterface::class);
+        $requestIdentifierMock->expects(self::once())
+                                    ->method('getRootAppRequestId')
+                                    ->willReturn($values['root']);
+        $requestIdentifierMock->expects(self::once())
+                                    ->method('getParentAppRequestId')
+                                    ->willReturn($values['parent']);
+        $requestIdentifierMock->expects(self::once())
+                                    ->method('getCurrentAppRequestId')
+                                    ->willReturn($values['current']);
+
+        $processor = new RequestIdentifierProcessor($requestIdentifierMock);
+        $record = $processor(
+            [
+                'message' => 'test',
+                'context' => [],
+                'level' => Logger::WARNING,
+                'level_name' => Logger::getLevelName(Logger::WARNING),
+                'channel' => 'test',
+                'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
+                'extra' => [],
+            ]
+        );
+
+        $this->assertArrayHasKey('request_id', $record['extra']);
+        $this->assertEquals($values['current'], $record['extra']['request_id']['current']);
+        $this->assertEquals($values['root'], $record['extra']['request_id']['root']);
+        $this->assertEquals($values['parent'], $record['extra']['request_id']['parent']);
+    }
+
+    public function testProcessorDoNothingIfNoRequestIdentifier()
+    {
+        $values = [
+            'current' => '',
+            'root' => '',
+            'parent' => null,
+        ];
+
+        $requestIdentifierFacadeMock = $this->createMock(RequestIdentifierInterface::class);
+        $requestIdentifierFacadeMock->expects(self::once())
+                                    ->method('getRootAppRequestId')
+                                    ->willReturn($values['root']);
+        $requestIdentifierFacadeMock->expects(self::once())
+                                    ->method('getParentAppRequestId')
+                                    ->willReturn($values['parent']);
+        $requestIdentifierFacadeMock->expects(self::once())
+                                    ->method('getCurrentAppRequestId')
+                                    ->willReturn($values['current']);
+
+        $processor = new RequestIdentifierProcessor($requestIdentifierFacadeMock);
+        $record = $processor(
+            [
+                'message' => 'test',
+                'context' => [],
+                'level' => Logger::WARNING,
+                'level_name' => Logger::getLevelName(Logger::WARNING),
+                'channel' => 'test',
+                'datetime' => \DateTime::createFromFormat('U.u', sprintf('%.6F', microtime(true))),
+                'extra' => [],
+            ]
+        );
+
+        $this->assertArrayNotHasKey('request_id', $record['extra']);
+    }
+}

--- a/tests/ProcessIdentifierFacadeTest.php
+++ b/tests/ProcessIdentifierFacadeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests;
+
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierFacade;
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JulienDufresne\InterAppRequestIdentifier\RequestIdentifierFacade
+ */
+final class ProcessIdentifierFacadeTest extends TestCase
+{
+    /** @var RequestIdentifierInterface|MockObject */
+    private $requestIdentifierMock;
+
+    public function setUp()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        parent::setUp();
+
+        $this->requestIdentifierMock = $this->createMock(RequestIdentifierInterface::class);
+        $this->requestIdentifierMock->expects(self::any())
+                              ->method('getRootAppRequestId')
+                              ->willReturn('A');
+        $this->requestIdentifierMock->expects(self::any())
+                              ->method('getParentAppRequestId')
+                              ->willReturn('B');
+        $this->requestIdentifierMock->expects(self::any())
+                              ->method('getCurrentAppRequestId')
+                              ->willReturn('C');
+    }
+
+    public function testCreateEmpty()
+    {
+        $object = new RequestIdentifierFacade();
+
+        $this->assertEquals('', $object->getRootAppRequestId());
+        $this->assertNull($object->getParentAppRequestId());
+        $this->assertEquals('', $object->getCurrentAppRequestId());
+    }
+
+    public function testCreateWithRequestIdentifier()
+    {
+        $object = new RequestIdentifierFacade($this->requestIdentifierMock);
+
+        $this->assertEquals('A', $object->getRootAppRequestId());
+        $this->assertEquals('B', $object->getParentAppRequestId());
+        $this->assertEquals('C', $object->getCurrentAppRequestId());
+    }
+
+    public function testInitProcessIdentifier()
+    {
+        $object = new RequestIdentifierFacade();
+
+        $requestIdentifierMock = $this->createMock(RequestIdentifierInterface::class);
+
+        $object->initRequestIdentifier($requestIdentifierMock);
+
+        $this->expectException(\LogicException::class);
+        $object->initRequestIdentifier($requestIdentifierMock);
+    }
+}

--- a/tests/RequestIdentifierTest.php
+++ b/tests/RequestIdentifierTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JulienDufresne\InterAppRequestIdentifier\Tests;
+
+use JulienDufresne\InterAppRequestIdentifier\RequestIdentifier;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \JulienDufresne\InterAppRequestIdentifier\RequestIdentifier
+ */
+final class RequestIdentifierTest extends TestCase
+{
+    public function testCreate()
+    {
+        $object = new RequestIdentifier('foo', 'bar', 'baz');
+
+        $this->assertEquals('foo', $object->getCurrentAppRequestId());
+        $this->assertEquals('bar', $object->getParentAppRequestId());
+        $this->assertEquals('baz', $object->getRootAppRequestId());
+    }
+
+    public function testCreateWithParent()
+    {
+        $object = new RequestIdentifier('foo', 'bar');
+
+        $this->assertEquals('foo', $object->getCurrentAppRequestId());
+        $this->assertEquals('bar', $object->getParentAppRequestId());
+        $this->assertEquals('bar', $object->getRootAppRequestId());
+    }
+
+    public function testCreateWithDefault()
+    {
+        $object = new RequestIdentifier('foo');
+
+        $this->assertEquals('foo', $object->getCurrentAppRequestId());
+        $this->assertEquals('foo', $object->getRootAppRequestId());
+        $this->assertNull($object->getParentAppRequestId());
+    }
+}


### PR DESCRIPTION
Provide basic implementation of request identifiers which contain:
* an identifier for the current running application process
* an identifier for the parent (caller) application process
* an identifier for the root (main) application process

It also adds two plugins:
* a Guzzle client wrapper to add headers to the request
* a Monolog processor to add request_id entries in logs