### PR TITLE
Handle headers case insensitivity

### DIFF
--- a/tests/Factory/RequestIdFromRequestFactoryTest.php
+++ b/tests/Factory/RequestIdFromRequestFactoryTest.php
@@ -101,6 +101,21 @@ final class RequestIdFromRequestFactoryTest extends TestCase
                 'bar',
                 'baz',
             ],
+            'case insensitive' => [
+                'headers' => [
+                    'x-parent-request-id' => 'bar',
+                    'x-root-request-id' => 'baz',
+                    'Accept' => '*/*',
+                    'Accept-Language' => 'en-us',
+                    'Accept-Encoding' => 'gzip, deflate',
+                    'User-Agent' => 'Mozilla/4.0',
+                    'Host' => 'www.example.com',
+                    'Connection' => 'Keep-Alive',
+                ],
+                'foo',
+                'bar',
+                'baz',
+            ],
         ];
     }
 }


### PR DESCRIPTION
According to [RFC2730], an header's field name is case insensitive.

[RFC2730]: https://tools.ietf.org/html/rfc7230#section-3.2