### PR TITLE
Improve readable of namespace and object names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Example
 -------
 
 ```php
-use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\RamseyUuidGenerator;
-use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromConsoleFactory;
-use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromRequestFactory;
+use JulienDufresne\RequestId\Factory\Generator\RamseyUuidGenerator;
+use JulienDufresne\RequestId\Factory\RequestIdFromConsoleFactory;
+use JulienDufresne\RequestId\Factory\RequestIdFromRequestFactory;
 
 $generator = new RamseyUuidGenerator();
 
@@ -62,7 +62,7 @@ If you are using guzzle (package guzzlehttp/guzzle) to perform http requests, yo
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+use JulienDufresne\RequestId\Guzzle\RequestIdMiddleware;
 
 $requestIdMiddleware = new RequestIdMiddleware(/* $requestIdentifier */);
 
@@ -76,8 +76,8 @@ $client = new Client(['handler' => $stack]);
 or use our factory to create a guzzle client:
 
 ```php
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\ClientFactory;
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+use JulienDufresne\RequestId\Guzzle\ClientFactory;
+use JulienDufresne\RequestId\Guzzle\RequestIdMiddleware;
 
 $requestIdMiddleware = new RequestIdMiddleware(/* $requestIdentifier */);
 
@@ -94,7 +94,7 @@ By default, sent headers are:
 You can change this in the middleware:
 
 ```php
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+use JulienDufresne\RequestId\Guzzle\RequestIdMiddleware;
 
 $requestIdMiddleware = new RequestIdMiddleware(
     /* $requestIdentifier */,
@@ -111,7 +111,7 @@ Monolog
 If you are using monolog to manage your application logs, you can use the [RequestIdentifierProcessor](/src/Monolog/RequestIdentifierProcessor.php):
 
 ```php
-use JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor;
+use JulienDufresne\RequestId\Monolog\RequestIdentifierProcessor;
 use Monolog\Logger;
 
 $processor = new RequestIdentifierProcessor(/* $requestIdentifier */);
@@ -132,7 +132,7 @@ By default, the processor will add a `request_id` array entry in the `extra` sec
 You can change this in the processor instantiation:
 
 ```php
-use JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor;
+use JulienDufresne\RequestId\Monolog\RequestIdentifierProcessor;
 
 $processor = new RequestIdentifierProcessor(
     /* $requestIdentifier */,

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     },
     "autoload": {
         "psr-4": {
-            "JulienDufresne\\InterAppRequestIdentifier\\": "src/"
+            "JulienDufresne\\RequestId\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "JulienDufresne\\InterAppRequestIdentifier\\Tests\\": "tests/"
+            "JulienDufresne\\RequestId\\Tests\\": "tests/"
         }
     },
     "license": "MIT",

--- a/src/Factory/AbstractRequestIdFactory.php
+++ b/src/Factory/AbstractRequestIdFactory.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Factory;
+namespace JulienDufresne\RequestId\Factory;
 
-use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\RequestId\Factory\Generator\UniqueIdGeneratorInterface;
 
-abstract class AbstractRequestIdentifierFactory
+abstract class AbstractRequestIdFactory
 {
     /** @var UniqueIdGeneratorInterface */
     protected $uniqueIdentifierGenerator;

--- a/src/Factory/Generator/RamseyUuidGenerator.php
+++ b/src/Factory/Generator/RamseyUuidGenerator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator;
+namespace JulienDufresne\RequestId\Factory\Generator;
 
 use Ramsey\Uuid\Uuid;
 

--- a/src/Factory/Generator/UniqueIdGeneratorInterface.php
+++ b/src/Factory/Generator/UniqueIdGeneratorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator;
+namespace JulienDufresne\RequestId\Factory\Generator;
 
 /**
  * Interface that your generator must implement to provide a way to generate unique identifier.

--- a/src/Factory/RequestIdFromConsoleFactory.php
+++ b/src/Factory/RequestIdFromConsoleFactory.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Factory;
+namespace JulienDufresne\RequestId\Factory;
 
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifier;
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use JulienDufresne\RequestId\RequestId;
+use JulienDufresne\RequestId\RequestIdInterface;
 
-final class RequestIdFromConsoleFactory extends AbstractRequestIdentifierFactory
+final class RequestIdFromConsoleFactory extends AbstractRequestIdFactory
 {
-    public function create(?string $parentRequestId = null, ?string $rootRequestId = null): RequestIdentifierInterface
+    public function create(?string $parentRequestId = null, ?string $rootRequestId = null): RequestIdInterface
     {
         $current = $this->uniqueIdentifierGenerator->generateUniqueIdentifier();
 
-        return new RequestIdentifier($current, $parentRequestId, $rootRequestId);
+        return new RequestId($current, $parentRequestId, $rootRequestId);
     }
 }

--- a/src/Factory/RequestIdFromRequestFactory.php
+++ b/src/Factory/RequestIdFromRequestFactory.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Factory;
+namespace JulienDufresne\RequestId\Factory;
 
-use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifier;
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use JulienDufresne\RequestId\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\RequestId\RequestId;
+use JulienDufresne\RequestId\RequestIdInterface;
 
-final class RequestIdFromRequestFactory extends AbstractRequestIdentifierFactory
+final class RequestIdFromRequestFactory extends AbstractRequestIdFactory
 {
     /** @var string */
     private $parentRequestIdHeaderName;
@@ -28,14 +28,14 @@ final class RequestIdFromRequestFactory extends AbstractRequestIdentifierFactory
     /**
      * @param string[] $requestHeaders list of all your request headers
      *
-     * @return RequestIdentifierInterface
+     * @return RequestIdInterface
      */
-    public function create(array $requestHeaders): RequestIdentifierInterface
+    public function create(array $requestHeaders): RequestIdInterface
     {
         $current = $this->uniqueIdentifierGenerator->generateUniqueIdentifier();
         $requestHeaders = $this->sanitizeHeaderKeys($requestHeaders);
 
-        return new RequestIdentifier(
+        return new RequestId(
             $current,
             $this->extractHeader($requestHeaders, $this->parentRequestIdHeaderName),
             $this->extractHeader($requestHeaders, $this->rootRequestIdHeaderName)

--- a/src/Guzzle/ClientFactory.php
+++ b/src/Guzzle/ClientFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Guzzle;
+namespace JulienDufresne\RequestId\Guzzle;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;

--- a/src/Guzzle/RequestIdMiddleware.php
+++ b/src/Guzzle/RequestIdMiddleware.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Guzzle;
+namespace JulienDufresne\RequestId\Guzzle;
 
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use JulienDufresne\RequestId\RequestIdInterface;
 use Psr\Http\Message\RequestInterface;
 
 /*final */class RequestIdMiddleware
@@ -12,7 +12,7 @@ use Psr\Http\Message\RequestInterface;
     const DEFAULT_REQUEST_HEADER_NAME_ROOT = 'X-Root-Request-Id';
     const DEFAULT_REQUEST_HEADER_NAME_PARENT = 'X-Parent-Request-Id';
 
-    /** @var RequestIdentifierInterface */
+    /** @var RequestIdInterface */
     private $requestIdentifier;
     /** @var string */
     private $parentAppRequestHeaderName;
@@ -20,7 +20,7 @@ use Psr\Http\Message\RequestInterface;
     private $rootAppRequestHeaderName;
 
     public function __construct(
-        RequestIdentifierInterface $requestIdentifier,
+        RequestIdInterface $requestIdentifier,
         string $rootAppRequestHeaderName = self::DEFAULT_REQUEST_HEADER_NAME_ROOT,
         string $parentAppRequestHeaderName = self::DEFAULT_REQUEST_HEADER_NAME_PARENT
     ) {

--- a/src/Monolog/RequestIdProcessor.php
+++ b/src/Monolog/RequestIdProcessor.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Monolog;
+namespace JulienDufresne\RequestId\Monolog;
 
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use JulienDufresne\RequestId\RequestIdInterface;
 
-final class RequestIdentifierProcessor
+final class RequestIdProcessor
 {
     /** @var string */
     private $extraEntryName;
-    /** @var RequestIdentifierInterface */
+    /** @var RequestIdInterface */
     private $requestIdentifier;
     /** @var string */
     private $rootAppEntryName;
@@ -20,14 +20,14 @@ final class RequestIdentifierProcessor
     private $currentAppEntryName;
 
     /**
-     * @param RequestIdentifierInterface $requestIdentifier
-     * @param string                     $extraEntryName
-     * @param string                     $currentAppEntryName
-     * @param string                     $rootAppEntryName
-     * @param string                     $parentAppEntryName
+     * @param RequestIdInterface $requestIdentifier
+     * @param string             $extraEntryName
+     * @param string             $currentAppEntryName
+     * @param string             $rootAppEntryName
+     * @param string             $parentAppEntryName
      */
     public function __construct(
-        RequestIdentifierInterface $requestIdentifier,
+        RequestIdInterface $requestIdentifier,
         string $extraEntryName = 'request_id',
         string $currentAppEntryName = 'current',
         string $rootAppEntryName = 'root',

--- a/src/RequestId.php
+++ b/src/RequestId.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier;
+namespace JulienDufresne\RequestId;
 
 /**
  * Determines the context of the application's current execution.
  */
-final class RequestIdentifier implements RequestIdentifierInterface
+final class RequestId implements RequestIdInterface
 {
     /** @var string */
     private $root;

--- a/src/RequestIdInterface.php
+++ b/src/RequestIdInterface.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier;
+namespace JulienDufresne\RequestId;
 
-interface RequestIdentifierInterface
+interface RequestIdInterface
 {
     /**
      * Uniquely identifies the root application execution id.

--- a/tests/Factory/Generator/RamseyUuidGeneratorTest.php
+++ b/tests/Factory/Generator/RamseyUuidGeneratorTest.php
@@ -6,7 +6,7 @@ namespace {
     $mockClassExistsFunction = false;
 }
 
-namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator {
+namespace JulienDufresne\RequestId\Factory\Generator {
     // override the global class_exists function used in the RamseyUuidGenerator class to test both scenario
     function class_exists($className)
     {
@@ -20,12 +20,12 @@ namespace JulienDufresne\InterAppRequestIdentifier\Factory\Generator {
     }
 }
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests\Factory\Generator {
-    use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\RamseyUuidGenerator;
+namespace JulienDufresne\RequestId\Tests\Factory\Generator {
+    use JulienDufresne\RequestId\Factory\Generator\RamseyUuidGenerator;
     use PHPUnit\Framework\TestCase;
 
     /**
-     * @covers \JulienDufresne\InterAppRequestIdentifier\Factory\Generator\RamseyUuidGenerator
+     * @covers \JulienDufresne\RequestId\Factory\Generator\RamseyUuidGenerator
      */
     final class RamseyUuidGeneratorTest extends TestCase
     {

--- a/tests/Factory/RequestIdFromConsoleFactoryTest.php
+++ b/tests/Factory/RequestIdFromConsoleFactoryTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests\Factory;
+namespace JulienDufresne\RequestId\Tests\Factory;
 
-use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
-use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromConsoleFactory;
+use JulienDufresne\RequestId\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\RequestId\Factory\RequestIdFromConsoleFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromConsoleFactory
+ * @covers \JulienDufresne\RequestId\Factory\RequestIdFromConsoleFactory
  */
 final class RequestIdFromConsoleFactoryTest extends TestCase
 {

--- a/tests/Factory/RequestIdFromRequestFactoryTest.php
+++ b/tests/Factory/RequestIdFromRequestFactoryTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests\Factory;
+namespace JulienDufresne\RequestId\Tests\Factory;
 
-use JulienDufresne\InterAppRequestIdentifier\Factory\Generator\UniqueIdGeneratorInterface;
-use JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromRequestFactory;
+use JulienDufresne\RequestId\Factory\Generator\UniqueIdGeneratorInterface;
+use JulienDufresne\RequestId\Factory\RequestIdFromRequestFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \JulienDufresne\InterAppRequestIdentifier\Factory\RequestIdFromRequestFactory
+ * @covers \JulienDufresne\RequestId\Factory\RequestIdFromRequestFactory
  */
 final class RequestIdFromRequestFactoryTest extends TestCase
 {

--- a/tests/Guzzle/ClientFactoryTest.php
+++ b/tests/Guzzle/ClientFactoryTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests\Guzzle;
+namespace JulienDufresne\RequestId\Tests\Guzzle;
 
 use GuzzleHttp\HandlerStack;
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\ClientFactory;
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
+use JulienDufresne\RequestId\Guzzle\ClientFactory;
+use JulienDufresne\RequestId\Guzzle\RequestIdMiddleware;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \JulienDufresne\InterAppRequestIdentifier\Guzzle\ClientFactory
+ * @covers \JulienDufresne\RequestId\Guzzle\ClientFactory
  */
 final class ClientFactoryTest extends TestCase
 {

--- a/tests/Guzzle/RequestIdMiddlewareTest.php
+++ b/tests/Guzzle/RequestIdMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests\Guzzle;
+namespace JulienDufresne\RequestId\Tests\Guzzle;
 
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -10,8 +10,8 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use JulienDufresne\InterAppRequestIdentifier\Guzzle\RequestIdMiddleware;
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use JulienDufresne\RequestId\Guzzle\RequestIdMiddleware;
+use JulienDufresne\RequestId\RequestIdInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
@@ -48,7 +48,7 @@ final class RequestIdMiddlewareTest extends TestCase
                 },
             ]
         );
-        $requestIdentifierMock = $this->createMock(RequestIdentifierInterface::class);
+        $requestIdentifierMock = $this->createMock(RequestIdInterface::class);
         $requestIdentifierMock->expects(self::once())
                                     ->method('getRootAppRequestId')
                                     ->willReturn($rootHeaderValue);

--- a/tests/Monolog/RequestIdProcessorTest.php
+++ b/tests/Monolog/RequestIdProcessorTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests\Monolog;
+namespace JulienDufresne\RequestId\Tests\Monolog;
 
-use JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor;
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifierInterface;
+use JulienDufresne\RequestId\Monolog\RequestIdProcessor;
+use JulienDufresne\RequestId\RequestIdInterface;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \JulienDufresne\InterAppRequestIdentifier\Monolog\RequestIdentifierProcessor
+ * @covers \JulienDufresne\RequestId\Monolog\RequestIdProcessor
  */
-final class RequestIdentifierProcessorTest extends TestCase
+final class RequestIdProcessorTest extends TestCase
 {
     public function testProcessor()
     {
@@ -22,7 +22,7 @@ final class RequestIdentifierProcessorTest extends TestCase
             'parent' => 'C',
         ];
 
-        $requestIdentifierMock = $this->createMock(RequestIdentifierInterface::class);
+        $requestIdentifierMock = $this->createMock(RequestIdInterface::class);
         $requestIdentifierMock->expects(self::once())
                                     ->method('getRootAppRequestId')
                                     ->willReturn($values['root']);
@@ -33,7 +33,7 @@ final class RequestIdentifierProcessorTest extends TestCase
                                     ->method('getCurrentAppRequestId')
                                     ->willReturn($values['current']);
 
-        $processor = new RequestIdentifierProcessor($requestIdentifierMock);
+        $processor = new RequestIdProcessor($requestIdentifierMock);
         $record = $processor(
             [
                 'message' => 'test',
@@ -60,7 +60,7 @@ final class RequestIdentifierProcessorTest extends TestCase
             'parent' => null,
         ];
 
-        $requestIdentifierFacadeMock = $this->createMock(RequestIdentifierInterface::class);
+        $requestIdentifierFacadeMock = $this->createMock(RequestIdInterface::class);
         $requestIdentifierFacadeMock->expects(self::once())
                                     ->method('getRootAppRequestId')
                                     ->willReturn($values['root']);
@@ -71,7 +71,7 @@ final class RequestIdentifierProcessorTest extends TestCase
                                     ->method('getCurrentAppRequestId')
                                     ->willReturn($values['current']);
 
-        $processor = new RequestIdentifierProcessor($requestIdentifierFacadeMock);
+        $processor = new RequestIdProcessor($requestIdentifierFacadeMock);
         $record = $processor(
             [
                 'message' => 'test',

--- a/tests/RequestIdTest.php
+++ b/tests/RequestIdTest.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace JulienDufresne\InterAppRequestIdentifier\Tests;
+namespace JulienDufresne\RequestId\Tests;
 
-use JulienDufresne\InterAppRequestIdentifier\RequestIdentifier;
+use JulienDufresne\RequestId\RequestId;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \JulienDufresne\InterAppRequestIdentifier\RequestIdentifier
+ * @covers \JulienDufresne\RequestId\RequestId
  */
-final class RequestIdentifierTest extends TestCase
+final class RequestIdTest extends TestCase
 {
     public function testCreate()
     {
-        $object = new RequestIdentifier('foo', 'bar', 'baz');
+        $object = new RequestId('foo', 'bar', 'baz');
 
         $this->assertEquals('foo', $object->getCurrentAppRequestId());
         $this->assertEquals('bar', $object->getParentAppRequestId());
@@ -23,7 +23,7 @@ final class RequestIdentifierTest extends TestCase
 
     public function testCreateWithParent()
     {
-        $object = new RequestIdentifier('foo', 'bar');
+        $object = new RequestId('foo', 'bar');
 
         $this->assertEquals('foo', $object->getCurrentAppRequestId());
         $this->assertEquals('bar', $object->getParentAppRequestId());
@@ -32,7 +32,7 @@ final class RequestIdentifierTest extends TestCase
 
     public function testCreateWithDefault()
     {
-        $object = new RequestIdentifier('foo');
+        $object = new RequestId('foo');
 
         $this->assertEquals('foo', $object->getCurrentAppRequestId());
         $this->assertEquals('foo', $object->getRootAppRequestId());


### PR DESCRIPTION
Namespace JulienDufresne\InterAppRequestIdentifier was too long.
Changing it to JulienDufresne\RequestId make it more readable.

Object names were also not normalized. Some of them were refering
to RequestIdentifier, others to RequestId.
Refactoring all of them to RequestId make it also more readable